### PR TITLE
Version 0.9.5 => 0.9.6  last publish bug fixed.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9310,7 +9310,7 @@
     },
     "packages/core": {
       "name": "@microlight/core",
-      "version": "0.9.5",
+      "version": "0.9.6",
       "dependencies": {
         "@babel/generator": "^7.26.10",
         "@babel/parser": "^7.26.10",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microlight/core",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "private": false,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
The last publish v0.9.5 seems missed any step.  - building code, fetch latest code from remote any.

The issue fixed in the new version and published and package.